### PR TITLE
Add keyboard event to navigate the race-chart

### DIFF
--- a/projects/shared/src/lib/charts/race-chart.ts
+++ b/projects/shared/src/lib/charts/race-chart.ts
@@ -34,6 +34,12 @@ export class RaceChart extends AbstractChart {
               this.button = this.toolbar.querySelector('.play mat-icon') as HTMLElement;
               this.input = this.toolbar.querySelector('input') as HTMLInputElement;
               this.input.onclick = (ev: any) => this.tick(parseInt(ev.target.value));
+              this.input.onkeyup = (ev: any) => {
+                const { key, target } = ev;
+                if (key === 'ArrowLeft' || key === 'ArrowRight') {
+                    this.tick(parseInt(target.value));
+                }
+              }
               (this.toolbar.querySelector('.play') as HTMLButtonElement).onclick = () => this.toggle();
               (this.toolbar.querySelector('.rewind') as HTMLButtonElement).onclick = () => this.changeSpeed(() => this.speed * 2);
               (this.toolbar.querySelector('.forward') as HTMLButtonElement).onclick = () => this.changeSpeed(() => this.speed / 2);

--- a/projects/shared/src/lib/charts/race-chart.ts
+++ b/projects/shared/src/lib/charts/race-chart.ts
@@ -33,13 +33,7 @@ export class RaceChart extends AbstractChart {
               this.speedText = this.toolbar.querySelector('.current') as HTMLElement;
               this.button = this.toolbar.querySelector('.play mat-icon') as HTMLElement;
               this.input = this.toolbar.querySelector('input') as HTMLInputElement;
-              this.input.onclick = (ev: any) => this.tick(parseInt(ev.target.value));
-              this.input.onkeyup = (ev: any) => {
-                const { key, target } = ev;
-                if (key === 'ArrowLeft' || key === 'ArrowRight') {
-                    this.tick(parseInt(target.value));
-                }
-              }
+              this.input.onchange = (ev: any) => this.tick(parseInt(ev.target.value));
               (this.toolbar.querySelector('.play') as HTMLButtonElement).onclick = () => this.toggle();
               (this.toolbar.querySelector('.rewind') as HTMLButtonElement).onclick = () => this.changeSpeed(() => this.speed * 2);
               (this.toolbar.querySelector('.forward') as HTMLButtonElement).onclick = () => this.changeSpeed(() => this.speed / 2);


### PR DESCRIPTION
I added a keyboard listener for the arrow key when the race-chart's range input is focused. In this way, it will be possible to navigate the chart by using the left and right keys.